### PR TITLE
Fixed passing API key when instantiating

### DIFF
--- a/steamwebapi/api.py
+++ b/steamwebapi/api.py
@@ -99,9 +99,9 @@ class _SteamWebAPI(object):
         return formatted_data
 
 class ISteamUser(_SteamWebAPI):
-    def __init__(self):
+    def __init__(self,**kwargs):
         self.interface = 'ISteamUser'
-        super(ISteamUser, self).__init__()
+        super(ISteamUser, self).__init__(**kwargs)
 
     def get_friends_list(self, steamID, relationship='all', format=None):
         """Request the friends list of a given steam ID filtered by role.
@@ -183,9 +183,9 @@ class ISteamUser(_SteamWebAPI):
         return self.return_data(data, format=format)
 
 class ISteamUserStats(_SteamWebAPI):
-    def __init__(self):
+    def __init__(self,**kwargs):
         self.interface = 'ISteamUserStats'
-        super(ISteamUserStats, self).__init__()
+        super(ISteamUserStats, self).__init__(**kwargs)
 
     def get_global_achievement_percentages_for_app(self, gameID, format=None):
         """Request statistics showing global achievements that have been 
@@ -307,9 +307,9 @@ class ISteamUserStats(_SteamWebAPI):
         return self.return_data(data, format=format)
 
 class IPlayerService(_SteamWebAPI):
-    def __init__(self):
+    def __init__(self,**kwargs):
         self.interface = 'IPlayerService'
-        super(IPlayerService, self).__init__()
+        super(IPlayerService, self).__init__(**kwargs)
 
     # RecordOfflinePlaytime, requires auth ticket
 
@@ -417,9 +417,9 @@ class IPlayerService(_SteamWebAPI):
         return self.return_data(data, format=format)
 
 class ISteamWebAPIUtil(_SteamWebAPI):
-    def __init__(self):
+    def __init__(self,**kwargs):
         self.interface = 'ISteamWebAPIUtil'
-        super(ISteamWebAPIUtil, self).__init__()
+        super(ISteamWebAPIUtil, self).__init__(**kwargs)
 
     def get_server_info(self, format=None):
         """Request the Steam Web API status and time.
@@ -453,8 +453,8 @@ class SteamCommunityXML(_SteamWebAPI):
     USER = 0
     GROUP = 1
 
-    def __init__(self):
-        super(SteamCommunityXML, self).__init__()
+    def __init__(self,**kwargs):
+        super(SteamCommunityXML, self).__init__(**kwargs)
 
     def create_request_url(self, profile_type, steamID):
         """Create the url to submit to the Steam Community XML feed."""


### PR DESCRIPTION
The Steam API key can now actually be passed when instantiating a Steam
interface object like the documentation says
